### PR TITLE
Added the batchexecutor takes the runas user instead of the logged in

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <artifactId>batch-executer</artifactId>
     <groupId>nl.ciber.alfresco</groupId>
-    <version>1.0-SNAPSHOT</version>
+    <version>1.0</version>
     <packaging>jar</packaging>
 
     <name>Alfresco Batch Executer Tool</name>
@@ -117,7 +117,7 @@
                     <branch>refs/heads/mvn-repo</branch>
                     <includes><include>**/*</include></includes>
                     <repositoryName>alfresco-js-batch-executer</repositoryName>
-                    <repositoryOwner>ciber</repositoryOwner>
+                    <repositoryOwner>shazada</repositoryOwner>
                 </configuration>
                 <executions>
                   <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
@@ -284,9 +284,10 @@
 
     <!-- Uses GitHub for source management -->
     <scm>
-        <connection>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</connection>
-        <url>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</url>
-        <developerConnection>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</developerConnection>
-    </scm>
+        <connection>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</connection>
+        <url>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</url>
+        <developerConnection>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</developerConnection>
+      <tag>batch-executer-1.0</tag>
+  </scm>
 
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
     <artifactId>batch-executer</artifactId>
     <groupId>nl.ciber.alfresco</groupId>
-    <version>1.0</version>
+    <version>1.0-SNAPSHOT</version>
     <packaging>jar</packaging>
 
     <name>Alfresco Batch Executer Tool</name>
@@ -117,7 +117,7 @@
                     <branch>refs/heads/mvn-repo</branch>
                     <includes><include>**/*</include></includes>
                     <repositoryName>alfresco-js-batch-executer</repositoryName>
-                    <repositoryOwner>shazada</repositoryOwner>
+                    <repositoryOwner>ciber</repositoryOwner>
                 </configuration>
                 <executions>
                   <!-- run site-maven-plugin's 'site' target as part of the build's normal 'deploy' phase -->
@@ -284,10 +284,9 @@
 
     <!-- Uses GitHub for source management -->
     <scm>
-        <connection>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</connection>
-        <url>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</url>
-        <developerConnection>scm:git:git@github.com:shazada/alfresco-js-batch-executer.git</developerConnection>
-      <tag>batch-executer-1.0</tag>
-  </scm>
+        <connection>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</connection>
+        <url>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</url>
+        <developerConnection>scm:git:git@github.com:ciber/alfresco-js-batch-executer.git</developerConnection>
+    </scm>
 
 </project>

--- a/src/main/java/nl/ciber/alfresco/repo/jscript/batchexecuter/ScriptBatchExecuter.java
+++ b/src/main/java/nl/ciber/alfresco/repo/jscript/batchexecuter/ScriptBatchExecuter.java
@@ -123,7 +123,8 @@ public class ScriptBatchExecuter extends BaseScopableProcessorExtension implemen
             runningJobs.put(job.getId(), job);
 
             final Scriptable cachedScope = getScope();
-            final String user = AuthenticationUtil.getFullyAuthenticatedUser();
+            //final String user = AuthenticationUtil.getFullyAuthenticatedUser();
+            final String user = AuthenticationUtil.getRunAsUser();
 
             RetryingTransactionHelper rth = sr.getTransactionService().getRetryingTransactionHelper();
 

--- a/src/main/java/nl/ciber/alfresco/repo/jscript/batchexecuter/ScriptBatchExecuter.java
+++ b/src/main/java/nl/ciber/alfresco/repo/jscript/batchexecuter/ScriptBatchExecuter.java
@@ -123,7 +123,6 @@ public class ScriptBatchExecuter extends BaseScopableProcessorExtension implemen
             runningJobs.put(job.getId(), job);
 
             final Scriptable cachedScope = getScope();
-            //final String user = AuthenticationUtil.getFullyAuthenticatedUser();
             final String user = AuthenticationUtil.getRunAsUser();
 
             RetryingTransactionHelper rth = sr.getTransactionService().getRetryingTransactionHelper();


### PR DESCRIPTION
user.

This is needed when some tasks should be done by System or in case you've used the batchexecutor in a webscript where a runas user is specified.